### PR TITLE
Add safeguard against unmatched proto.

### DIFF
--- a/rules/no-use-extend-native.js
+++ b/rules/no-use-extend-native.js
@@ -59,7 +59,7 @@ module.exports = function (context) {
       methodName = methodName || node.property.name || node.property.value;
       type = node.parent.type;
 
-      if (!isJsType(proto)) {
+      if (typeof proto !== 'string' || !isJsType(proto)) {
         return;
       }
 


### PR DESCRIPTION
Add a check to ensure that `proto` was successfully assigned before checking against `isJsType`. 

Without this check, `isJsType` will throw causing eslint to bail out - failing completely. 

While this will hide the fact that an unmatched proto was found, it is unlikely that the user wants to run eslint against these files anyways. The result is that the file is silently skipped.