### PR TITLE
Meta type

### DIFF
--- a/src/no-use-extend-native.js
+++ b/src/no-use-extend-native.js
@@ -105,26 +105,33 @@ const isInvalid = (jsType, propertyName, usageType) => {
   return unknownGetterSetterOrjsTypeExpressed || getterSetterCalledAsFunction || unknownjsTypeCalledAsFunction
 }
 
-module.exports = context => ({
-  MemberExpression(node) {
-    /* eslint complexity: [2, 9] */
-    if (node.computed && node.property.type === 'Identifier') {
-      /**
-       * handles cases like {}[i][j]
-       * not enough information to identify type of variable in computed properties
-       * so ignore false positives by not performing any checks
-       */
+module.exports = {
+  meta: {
+    type: 'problem'
+  },
+  create(context) {
+    return {
+      MemberExpression(node) {
+        /* eslint complexity: [2, 9] */
+        if (node.computed && node.property.type === 'Identifier') {
+          /**
+           * handles cases like {}[i][j]
+           * not enough information to identify type of variable in computed properties
+           * so ignore false positives by not performing any checks
+           */
 
-      return
-    }
+          return
+        }
 
-    const isArgToParent = node.parent.arguments && node.parent.arguments.indexOf(node) > -1
-    const usageType = isArgToParent ? node.type : node.parent.type
+        const isArgToParent = node.parent.arguments && node.parent.arguments.indexOf(node) > -1
+        const usageType = isArgToParent ? node.type : node.parent.type
 
-    const {propertyName, jsType} = getJsTypeAndPropertyName(node)
+        const {propertyName, jsType} = getJsTypeAndPropertyName(node)
 
-    if (isInvalid(jsType, propertyName, usageType) && isInvalid('Function', propertyName, usageType)) {
-      context.report(node, 'Avoid using extended native objects')
+        if (isInvalid(jsType, propertyName, usageType) && isInvalid('Function', propertyName, usageType)) {
+          context.report(node, 'Avoid using extended native objects')
+        }
+      }
     }
   }
-})
+}


### PR DESCRIPTION
feat: use eslint's newer rule format along with `meta.type: "problem"`

- New format per https://eslint.org/blog/2016/07/eslint-new-rule-format
- meta.type allows use with `eslint --fix-type` (distinct from mere
"suggestion" or "layout"): https://eslint.org/docs/user-guide/command-line-interface#fix-type

(Though I know you don't have a fixer for this, I just mention where this "type" is used; I am personally interested in seeing it added as I am planning to release an eslint badge formatter which helps report group violations, with the option to count by type of violation (e.g., 10 "layout" violations, 20 "problem" violations, and 5 "suggestion" violations).)