### PR TITLE
refactor: remove babel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 coverage/
 node_modules/
-rules/
-!docs/rules/
 .nyc_output/

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 /* eslint no-var: 0 */
 'use strict'
-var rule = require('./rules/no-use-extend-native')
+var rule = require('./src/no-use-extend-native')
 
 module.exports = {
   rules: {

--- a/package.json
+++ b/package.json
@@ -3,15 +3,9 @@
   "version": "0.5.0",
   "description": "ESLint plugin to prevent use of extended native objects",
   "scripts": {
-    "compile": "babel src --source-maps --out-dir rules",
     "coveralls": "nyc report --reporter=text-lcov | coveralls",
     "lint": "eslint .",
-    "test": "npm run compile && npm run lint && nyc ava"
-  },
-  "ava": {
-    "require": [
-      "esm"
-    ]
+    "test": "npm run lint && nyc ava"
   },
   "repository": "https://github.com/dustinspecker/eslint-plugin-no-use-extend-native",
   "bugs": "https://github.com/dustinspecker/eslint-plugin-no-use-extend-native/issues",
@@ -33,7 +27,7 @@
   "license": "MIT",
   "files": [
     "index.js",
-    "rules"
+    "src"
   ],
   "dependencies": {
     "is-get-set-prop": "^1.0.0",
@@ -42,17 +36,13 @@
     "is-proto-prop": "^2.0.0"
   },
   "devDependencies": {
-    "@babel/cli": "^7.8.4",
-    "@babel/preset-env": "^7.9.6",
     "ava": "^3.8.2",
-    "babel-plugin-add-module-exports": "^1.0.2",
     "coveralls": "^3.1.0",
     "eslint": "^7.0.0",
     "eslint-ava-rule-tester": "^4.0.0",
     "eslint-config-dustinspecker": "^5.0.0",
     "eslint-path-formatter": "^0.1.1",
     "eslint-plugin-new-with-error": "^2.0.0",
-    "esm": "^3.2.25",
     "nyc": "^15.0.1"
   }
 }

--- a/src/no-use-extend-native.js
+++ b/src/no-use-extend-native.js
@@ -1,8 +1,8 @@
 'use strict'
-import isGetSetProp from 'is-get-set-prop'
-import isJsType from 'is-js-type'
-import isObjProp from 'is-obj-prop'
-import isProtoProp from 'is-proto-prop'
+const isGetSetProp = require('is-get-set-prop')
+const isJsType = require('is-js-type')
+const isObjProp = require('is-obj-prop')
+const isProtoProp = require('is-proto-prop')
 
 /**
  * Return type of value of left or right
@@ -105,7 +105,7 @@ const isInvalid = (jsType, propertyName, usageType) => {
   return unknownGetterSetterOrjsTypeExpressed || getterSetterCalledAsFunction || unknownjsTypeCalledAsFunction
 }
 
-export default {
+module.exports = {
   meta: {
     type: 'problem'
   },

--- a/test/test.js
+++ b/test/test.js
@@ -1,7 +1,7 @@
 'use strict'
-import AvaRuleTester from 'eslint-ava-rule-tester'
-import noUseExtendNative from '..'
-import test from 'ava'
+const AvaRuleTester = require('eslint-ava-rule-tester')
+const noUseExtendNative = require('..')
+const test = require('ava')
 
 const ruleTester = new AvaRuleTester(test)
 


### PR DESCRIPTION
Switch to using `require` and `module.exports` instead of `import` and `export default`.