### PR TITLE
Update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "eslint-ava-rule-tester": "^5.0.1",
     "eslint-config-dustinspecker": "^5.0.0",
     "eslint-path-formatter": "^0.1.1",
-    "eslint-plugin-new-with-error": "^2.0.0",
+    "eslint-plugin-new-with-error": "^5.0.0",
     "nyc": "^15.0.1"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "keywords": [
     "eslint",
     "eslintplugin",
+    "eslint-plugin",
     "extend",
     "native",
     "prototype"

--- a/package.json
+++ b/package.json
@@ -38,11 +38,13 @@
   "devDependencies": {
     "ava": "^6.1.3",
     "coveralls": "^3.1.0",
-    "eslint": "^7.0.0",
     "eslint-ava-rule-tester": "^4.0.0",
     "eslint-config-dustinspecker": "^5.0.0",
     "eslint-path-formatter": "^0.1.1",
     "eslint-plugin-new-with-error": "^2.0.0",
     "nyc": "^15.0.1"
+  },
+  "peerDependencies": {
+    "eslint": "^8.57.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "ava": "^6.1.3",
     "coveralls": "^3.1.0",
-    "eslint-ava-rule-tester": "^4.0.0",
+    "eslint-ava-rule-tester": "^5.0.1",
     "eslint-config-dustinspecker": "^5.0.0",
     "eslint-path-formatter": "^0.1.1",
     "eslint-plugin-new-with-error": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "is-proto-prop": "^2.0.0"
   },
   "devDependencies": {
-    "ava": "^3.8.2",
+    "ava": "^6.1.3",
     "coveralls": "^3.1.0",
     "eslint": "^7.0.0",
     "eslint-ava-rule-tester": "^4.0.0",

--- a/test/test.mjs
+++ b/test/test.mjs
@@ -1,7 +1,6 @@
-'use strict'
-const AvaRuleTester = require('eslint-ava-rule-tester')
-const noUseExtendNative = require('..')
-const test = require('ava')
+import AvaRuleTester from 'eslint-ava-rule-tester'
+import noUseExtendNative from '../index.js'
+import test from 'ava'
 
 const ruleTester = new AvaRuleTester(test)
 


### PR DESCRIPTION
Will handle ESLint 9 and eslint-config-dustinspecker (maybe just remove?) in another pull request.

Handle coverage reporting in another pull request.