### PR TITLE
fix: add `exports` to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "index.js",
     "src"
   ],
+  "exports": "./index.js",
   "dependencies": {
     "is-get-set-prop": "^2.0.0",
     "is-js-type": "^3.0.0",


### PR DESCRIPTION
This fixes the Node warning message you get when importing this package:

```
(Use `node --trace-deprecation ...` to show where the warning was created)
(node:57851) [DEP0151] DeprecationWarning: No "main" or "exports" field defined in the package.json for /github/privatenumber/lintroll/node_modules/eslint-plugin-no-use-extend-native/ resolving the main entry point "index.js", imported from /github/privatenumber/lintroll/dist/index-BVtdn9xd.mjs.
```